### PR TITLE
Chore/upgrade android reach five sdk

### DIFF
--- a/flutter_reach_five/CHANGELOG.md
+++ b/flutter_reach_five/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.8
+
+- **FIX** 🤖 Update Android SDK to 8.1.1 to fix Intent Redirection warning.
+
 # 0.1.7
 
 - Add support for retrieving Profile with getProfile

--- a/flutter_reach_five/pubspec.yaml
+++ b/flutter_reach_five/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_reach_five
 description: This package allows you to use the methods from the reachFive android and ios native sdks in Flutter
-version: 0.1.7
+version: 0.1.8
 homepage: https://github.com/bamlab/Flutter-ReachFive
 repository: https://github.com/bamlab/Flutter-ReachFive
 
@@ -22,13 +22,12 @@ dependencies:
   equatable: ^2.0.5
   flutter:
     sdk: flutter
-  flutter_reach_five_android: ^0.1.7
-  flutter_reach_five_ios: ^0.1.7
-  flutter_reach_five_platform_interface: ^0.1.7
+  flutter_reach_five_android: ^0.1.8
+  flutter_reach_five_ios: ^0.1.8
+  flutter_reach_five_platform_interface: ^0.1.8
   freezed: ^2.1.0+1
   freezed_annotation: ^2.1.0
-  reach_five_identity_repo: ^0.1.7
-
+  reach_five_identity_repo: ^0.1.8
 dev_dependencies:
   analyzer: ^4.7.0
   build_runner: ^2.2.0

--- a/flutter_reach_five_android/CHANGELOG.md
+++ b/flutter_reach_five_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.8
+
+- **FIX** 🤖 Update Android SDK to 8.1.1 to fix Intent Redirection warning.
+
 # 0.1.7
 
 - Add support for retrieving Profile with getProfile

--- a/flutter_reach_five_android/android/build.gradle
+++ b/flutter_reach_five_android/android/build.gradle
@@ -3,7 +3,7 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     ext {
-        sdk_version = "8.0.1"
+        sdk_version = "8.1.1"
         kotlin_version = '1.7.10'
 
         androidSettings = [

--- a/flutter_reach_five_android/pubspec.yaml
+++ b/flutter_reach_five_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_reach_five_android
 description: Android implementation of the flutter_reach_five plugin
-version: 0.1.7
+version: 0.1.8
 homepage: https://github.com/bamlab/Flutter-ReachFive
 
 environment:
@@ -19,8 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_reach_five_platform_interface: ^0.1.7
-
+  flutter_reach_five_platform_interface: ^0.1.8
 dev_dependencies:
   analyzer: ^4.7.0
   flutter_test:

--- a/flutter_reach_five_ios/CHANGELOG.md
+++ b/flutter_reach_five_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.8
+
+- **FIX** 🤖 Update Android SDK to 8.1.1 to fix Intent Redirection warning.
+
 # 0.1.7
 
 - Add support for retrieving Profile with getProfile

--- a/flutter_reach_five_ios/pubspec.yaml
+++ b/flutter_reach_five_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_reach_five_ios
 description: iOS implementation of the flutter_reach_five plugin
-version: 0.1.7
+version: 0.1.8
 homepage: https://github.com/bamlab/Flutter-ReachFive
 
 environment:
@@ -18,8 +18,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_reach_five_platform_interface: ^0.1.7
-
+  flutter_reach_five_platform_interface: ^0.1.8
 dev_dependencies:
   analyzer: ^4.7.0
   flutter_test:

--- a/flutter_reach_five_platform_interface/CHANGELOG.md
+++ b/flutter_reach_five_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.8
+
+- **FIX** 🤖 Update Android SDK to 8.1.1 to fix Intent Redirection warning.
+
 # 0.1.7
 
 - Add support for retrieving Profile with getProfile

--- a/flutter_reach_five_platform_interface/pubspec.yaml
+++ b/flutter_reach_five_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_reach_five_platform_interface
 description: A common platform interface for the flutter_reach_five plugin.
-version: 0.1.7
+version: 0.1.8
 homepage: https://github.com/bamlab/Flutter-ReachFive
 
 environment:

--- a/reach_five_identity_repo/CHANGELOG.md
+++ b/reach_five_identity_repo/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.8
+
+- **FIX** 🤖 Update Android SDK to 8.1.1 to fix Intent Redirection warning.
+
 # 0.1.7
 
 - Add support for retrieving Profile with getProfile (nothing changed for reach_five_identity_repo)

--- a/reach_five_identity_repo/pubspec.yaml
+++ b/reach_five_identity_repo/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reach_five_identity_repo
-version: 0.1.7
+version: 0.1.8
 description: OpenAPI API client
 homepage: https://github.com/bamlab/Flutter-ReachFive
 


### PR DESCRIPTION
## Description

- Upgrade android Reach Five sdk to fix an  Intent Redirection warning from the Play Store.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
