### PR TITLE
Feat/send email verification cleaner api

### DIFF
--- a/flutter_reach_five/CHANGELOG.md
+++ b/flutter_reach_five/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.6.0
+
+- **FEAT**: In the API of sendEmailVerification, instead of taking `authorization: 'Bearer $accessToken'` as a parameter, it now takes `accessToken: accessToken` to formats the header internally.
+
 # 0.5.0
 
 - **FEAT**: Add a method to handle user email verification

--- a/flutter_reach_five/lib/reach_five.dart
+++ b/flutter_reach_five/lib/reach_five.dart
@@ -181,7 +181,7 @@ class ReachFive {
   /// Returns a [bool] that indicates if the email was sent (`false` if the email was already verified).
   ///
   /// Parameters:
-  /// * [authorization] - Bearer `{token}` for a valid OAuth token.
+  /// * [accessToken] - Considering `authToken` a valid OAuth token, accessToken is `authToken.accessToken`.
   /// * [trueClientIP] - An optional header field; IP to protect requests from the backend.  **Note**: For more details, see [Identity Fraud Protection](https://developer.reachfive.com/docs/ifp.html#enable-true-client-ip-key).
   /// * [trueClientIPKey] - An optional header field; the secret that must match the True-Client-IP-Key generated in the ReachFive console.  **Note**: For more details, see [Identity Fraud Protection](https://developer.reachfive.com/docs/ifp.html#enable-true-client-ip-key).
   /// * [redirectUrl] - The URL sent in the verification email to which the profile is redirected. This URL must be whitelisted in the `Allowed Callback URLs` field of your ReachFive client settings.
@@ -189,7 +189,7 @@ class ReachFive {
   ///
   /// {@endtemplate}
   Future<bool> sendEmailVerification({
-    required String authorization,
+    required String accessToken,
     String? trueClientIP,
     String? trueClientIPKey,
     String? redirectUrl,
@@ -199,6 +199,8 @@ class ReachFive {
       redirectUrl: redirectUrl,
       returnToAfterEmailConfirmation: returnToAfterEmailConfirmation,
     );
+
+    final authorization = 'Bearer $accessToken';
 
     final response = await emailApi.sendEmailVerification(
       authorization: authorization,

--- a/flutter_reach_five/pubspec.yaml
+++ b/flutter_reach_five/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_reach_five
 description: This package allows you to use the methods from the reachFive android and ios native sdks in Flutter
-version: 0.5.0
+version: 0.6.0
 homepage: https://github.com/bamlab/Flutter-ReachFive
 repository: https://github.com/bamlab/Flutter-ReachFive
 

--- a/flutter_reach_five/test/reach_five_test.dart
+++ b/flutter_reach_five/test/reach_five_test.dart
@@ -631,12 +631,12 @@ void main() {
         );
 
         await reachFive.sendEmailVerification(
-          authorization: authToken.toString(),
+          accessToken: authToken.accessToken,
         );
 
         verify(
           () => mockEmailApi.sendEmailVerification(
-            authorization: authToken.toString(),
+            authorization: 'Bearer ${authToken.accessToken}',
             sendEmailVerificationRequest: SendEmailVerificationRequest(),
           ),
         ).called(1);


### PR DESCRIPTION
## Description

format the field `authorization` of `sendEmailVerification` in the plugin instead of asking users to do it on their own
`sendEmailVerification` now takes a simple `accessToken` parameter instead of `authorization`

## Type of Change


- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
