### PR TITLE
Add android support for AGP 8.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ buildTypes {
     }
 ```
 
+- to use the sdk in release mode, you also need to add these lines in your `android/gradle.properties` :
+
+```gradle
+android.enableR8.fullMode=false
+```
+
 ---
 
 ## iOS

--- a/flutter_reach_five/CHANGELOG.md
+++ b/flutter_reach_five/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.7.0
+
+- **BREAKING**: On android: add support for AGP 8.3.0. Breaks compatibility with AGP 7.2.2 and below.
+
 # 0.6.0
 
 - **FEAT**: In the API of sendEmailVerification, instead of taking `authorization: 'Bearer $accessToken'` as a parameter, it now takes `accessToken: accessToken` to formats the header internally.

--- a/flutter_reach_five/example/android/app/build.gradle
+++ b/flutter_reach_five/example/android/app/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace 'com.example.flutter_reach_five_example'
     compileSdkVersion 34
 
     compileOptions {

--- a/flutter_reach_five/example/android/app/proguard-rules.pro
+++ b/flutter_reach_five/example/android/app/proguard-rules.pro
@@ -23,3 +23,12 @@
 # We need to keep reachfive models from obfuscating otherwise there is
 # serialization/deserialization errors when building your app in release mode
 -keep class co.reachfive.identity.sdk.core.models.** {*;}
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE

--- a/flutter_reach_five/example/android/app/src/debug/AndroidManifest.xml
+++ b/flutter_reach_five/example/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.flutter_reach_five_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/flutter_reach_five/example/android/app/src/main/AndroidManifest.xml
+++ b/flutter_reach_five/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.flutter_reach_five_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
    <application
         android:label="flutter_reach_five_example"
         android:name="${applicationName}"

--- a/flutter_reach_five/example/android/app/src/profile/AndroidManifest.xml
+++ b/flutter_reach_five/example/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.flutter_reach_five_example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/flutter_reach_five/example/android/build.gradle
+++ b/flutter_reach_five/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:8.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/flutter_reach_five/example/android/gradle.properties
+++ b/flutter_reach_five/example/android/gradle.properties
@@ -4,3 +4,4 @@ android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+android.enableR8.fullMode=false

--- a/flutter_reach_five/example/android/gradle.properties
+++ b/flutter_reach_five/example/android/gradle.properties
@@ -1,3 +1,6 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xms512M -Xmx4g -XX:MaxMetaspaceSize=1g -Dkotlin.daemon.jvm.options="-Xmx1g"
 android.useAndroidX=true
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/flutter_reach_five/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter_reach_five/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/flutter_reach_five/pubspec.yaml
+++ b/flutter_reach_five/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_reach_five
 description: This package allows you to use the methods from the reachFive android and ios native sdks in Flutter
-version: 0.6.0
+version: 0.7.0
 homepage: https://github.com/bamlab/Flutter-ReachFive
 repository: https://github.com/bamlab/Flutter-ReachFive
 

--- a/flutter_reach_five_android/CHANGELOG.md
+++ b/flutter_reach_five_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5.0
+
+- **BREAKING**: On android: add support for AGP 8.3.0. Breaks compatibility with AGP 7.2.2 and below.
+
 # 0.4.1
 
 - **FEAT**: Add a custom exception thrown when the refresh token is not valid anymore

--- a/flutter_reach_five_android/android/build.gradle
+++ b/flutter_reach_five_android/android/build.gradle
@@ -34,6 +34,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'tech.bam.flutter_reach_five'
     compileSdkVersion androidSettings.compile_sdk_version
 
     compileOptions {

--- a/flutter_reach_five_android/android/src/main/AndroidManifest.xml
+++ b/flutter_reach_five_android/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="tech.bam.flutter_reach_five">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/flutter_reach_five_android/pubspec.yaml
+++ b/flutter_reach_five_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_reach_five_android
 description: Android implementation of the flutter_reach_five plugin
-version: 0.4.1
+version: 0.5.0
 homepage: https://github.com/bamlab/Flutter-ReachFive
 
 environment:


### PR DESCRIPTION
## Description

Today an app that uses AGP 8.3.0 can't use this plugin because of the use of the deprecated prop `package` in the manifest.
This PR changes it and specifies the app ID in the gradle file `android.namespace` prop.
This breaks apps using AGP 7.2.2 and below

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
