### PR TITLE
feat: add a custom locale property to the send verification email method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,111 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 2024-12-26
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`flutter_reach_five` - `v0.7.2`](#flutter_reach_five---v072)
+ - [`flutter_reach_five_android` - `v0.5.1`](#flutter_reach_five_android---v051)
+ - [`flutter_reach_five_ios` - `v0.4.2`](#flutter_reach_five_ios---v042)
+ - [`flutter_reach_five_platform_interface` - `v0.4.2`](#flutter_reach_five_platform_interface---v042)
+ - [`reach_five_identity_repo` - `v0.5.1`](#reach_five_identity_repo---v051)
+
+---
+
+#### `flutter_reach_five` - `v0.7.2`
+
+ - **REFACTOR**(reach_five): cleaner API.
+ - **REFACTOR**(android): clean build file structure.
+ - **FIX**(example): R8 after APG 8+.
+ - **FIX**: fix iOS version for reach five sdk.
+ - **FIX**: add missing brackets.
+ - **FEAT**: add a custom locale to the send verification email method.
+ - **FEAT**(public reachfive): sendEmailVerif cleaner API.
+ - **FEAT**(reach5): expose sendEmailVerification.
+ - **FEAT**(reach_five): add emailApi.
+ - **FEAT**(package): parse the unauthorize refresh token exception.
+ - **FEAT**(package): add a proper error for unauthorized refresh token.
+ - **FEAT**: add UpdateSamePassword exception to interface.
+
+#### `flutter_reach_five_android` - `v0.5.1`
+
+ - **REFACTOR**(android plugin): improve result type.
+ - **REFACTOR**(platform interface): rename error exception classes.
+ - **REFACTOR**(android converters): extract addressTypeFromInterface.
+ - **REFACTOR**(android): use ReachFiveKeyInterface.
+ - **REFACTOR**(pigeon): add ReachFiveKeyInterface.
+ - **REFACTOR**(android): create and use getReachFiveInstance function.
+ - **FIX**(android): plugin works with AGP 8.3.0.
+ - **FIX**(android): use the correct result class after pigeon update.
+ - **FIX**(android): bump android sdk version that secure intent redirect.
+ - **FIX**(Android parseError): use code instead of message.
+ - **FIX**(android plugin): load social providers after initialization.
+ - **FIX**(android): remove very_good_analysis dev dep.
+ - **FIX**(changelog): use correct versions.
+ - **FIX**(profilesignuprequest): make email optional.
+ - **FEAT**(android): handle unauthorize refresh token exception.
+ - **FEAT**(package): add a proper error for unauthorized refresh token.
+ - **FEAT**: add error handling for updateSamePassword error in android.
+ - **FEAT**: add UpdateSamePassword exception to interface.
+ - **FEAT**(android): add signup method.
+ - **FEAT**(android): initialize reachFive.
+ - **DOCS**(all_packages): link differents documentations.
+ - **DOCS**(every packages): complete readme files.
+
+#### `flutter_reach_five_ios` - `v0.4.2`
+
+ - **REFACTOR**(platform interface): rename error exception classes.
+ - **REFACTOR**(ios flutterreachfiveplugin): remove redundant return.
+ - **REFACTOR**(ios converters): remove redondant return.
+ - **REFACTOR**(ios converters): extract addressTypeFromInterface.
+ - **REFACTOR**(ios): use ReachFiveKeyInterface.
+ - **REFACTOR**(pigeon): add ReachFiveKeyInterface.
+ - **FIX**(ios converters): use liteOnly variable.
+ - **FIX**(changelog): use correct versions.
+ - **FIX**(profilesignuprequest): make email optional.
+ - **FEAT**(ios): handle unauthorize refresh token exception.
+ - **FEAT**(package): add a proper error for unauthorized refresh token.
+ - **FEAT**: add error handling for updateSamePassword error in iOS.
+ - **FEAT**: add UpdateSamePassword exception to interface.
+ - **FEAT**(ios): add refreshAccessToken method.
+ - **FEAT**(ios): add signup method.
+ - **FEAT**(ios): initialize reachFive.
+ - **DOCS**(all_packages): link differents documentations.
+ - **DOCS**(every packages): complete readme files.
+
+#### `flutter_reach_five_platform_interface` - `v0.4.2`
+
+ - **REFACTOR**(platform interface): rename error exception classes.
+ - **REFACTOR**(platform): use ReachFiveKeyInterface.
+ - **REFACTOR**(pigeon): add ReachFiveKeyInterface.
+ - **REFACTOR**(platform interface test): extract ReachFiveConfigInterface.
+ - **FIX**(platform errors): use correct docs links.
+ - **FIX**(platform interface): fix typo in readme.
+ - **FIX**(errors): export new errors from reach five main package.
+ - **FIX**(changelog): use correct versions.
+ - **FIX**(pigeon): format after file generation.
+ - **FIX**(profilesignuprequest): make email optional.
+ - **FEAT**(package): add a proper error for unauthorized refresh token.
+ - **FEAT**: add UpdateSamePassword exception to interface.
+ - **FEAT**(platform_interface): add refreshAccessToken method.
+ - **FEAT**(platform interface): add signup method.
+ - **DOCS**(all_packages): link differents documentations.
+ - **DOCS**(every packages): complete readme files.
+
+#### `reach_five_identity_repo` - `v0.5.1`
+
+ - **REFACTOR**(reach_five_repo): rename in reach_five_identity_repo.
+ - **FIX**: correct version for identity repo.
+ - **FEAT**: add custom local for send email endpoint.
+

--- a/flutter_reach_five/CHANGELOG.md
+++ b/flutter_reach_five/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.7.2
+
+ - **REFACTOR**(reach_five): cleaner API.
+ - **REFACTOR**(android): clean build file structure.
+ - **FIX**(example): R8 after APG 8+.
+ - **FIX**: fix iOS version for reach five sdk.
+ - **FIX**: add missing brackets.
+ - **FEAT**: add a custom locale to the send verification email method.
+ - **FEAT**(public reachfive): sendEmailVerif cleaner API.
+ - **FEAT**(reach5): expose sendEmailVerification.
+ - **FEAT**(reach_five): add emailApi.
+ - **FEAT**(package): parse the unauthorize refresh token exception.
+ - **FEAT**(package): add a proper error for unauthorized refresh token.
+ - **FEAT**: add UpdateSamePassword exception to interface.
+
 # 0.7.1
 
 - **Fix**: Update android dependencie.

--- a/flutter_reach_five/lib/reach_five.dart
+++ b/flutter_reach_five/lib/reach_five.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_reach_five_platform_interface/flutter_reach_five_platform_interface.dart';
 import 'package:reach_five_identity_repo/reach_five_identity_repo.dart';
 
@@ -186,6 +187,7 @@ class ReachFive {
   /// * [trueClientIPKey] - An optional header field; the secret that must match the True-Client-IP-Key generated in the ReachFive console.  **Note**: For more details, see [Identity Fraud Protection](https://developer.reachfive.com/docs/ifp.html#enable-true-client-ip-key).
   /// * [redirectUrl] - The URL sent in the verification email to which the profile is redirected. This URL must be whitelisted in the `Allowed Callback URLs` field of your ReachFive client settings.
   /// * [returnToAfterEmailConfirmation] - Returned in the `redirect_url` as a query parameter, this parameter is used as the post-email confirmation URL. It must be a valid URL.
+  /// * [customLocale] - For any endpoint in this specification that generates an email or SMS, you can pass the Custom-Locale attribute as a header parameter.
   ///
   /// {@endtemplate}
   Future<bool> sendEmailVerification({
@@ -194,6 +196,7 @@ class ReachFive {
     String? trueClientIPKey,
     String? redirectUrl,
     String? returnToAfterEmailConfirmation,
+    Locale? customLocale,
   }) async {
     final sendEmailVerificationRequest = SendEmailVerificationRequest(
       redirectUrl: redirectUrl,
@@ -207,6 +210,7 @@ class ReachFive {
       trueClientIP: trueClientIP,
       trueClientIPKey: trueClientIPKey,
       sendEmailVerificationRequest: sendEmailVerificationRequest,
+      customLocale: customLocale?.toLanguageTag(),
     );
 
     return response.data?.verificationEmailSent ?? false;

--- a/flutter_reach_five/pubspec.yaml
+++ b/flutter_reach_five/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_reach_five
 description: This package allows you to use the methods from the reachFive android and ios native sdks in Flutter
-version: 0.7.1
+version: 0.7.2
 homepage: https://github.com/bamlab/Flutter-ReachFive
 repository: https://github.com/bamlab/Flutter-ReachFive
 
@@ -22,12 +22,12 @@ dependencies:
   equatable: ^2.0.5
   flutter:
     sdk: flutter
-  flutter_reach_five_android: ^0.5.0
-  flutter_reach_five_ios: ^0.4.1
-  flutter_reach_five_platform_interface: ^0.4.1
+  flutter_reach_five_android: ^0.5.1
+  flutter_reach_five_ios: ^0.4.2
+  flutter_reach_five_platform_interface: ^0.4.2
   freezed: ^2.1.0+1
   freezed_annotation: ^2.1.0
-  reach_five_identity_repo: ^0.5.0
+  reach_five_identity_repo: ^0.5.1
 
 dev_dependencies:
   build_runner: ^2.4.8

--- a/flutter_reach_five/test/reach_five_test.dart
+++ b/flutter_reach_five/test/reach_five_test.dart
@@ -633,6 +633,38 @@ void main() {
 
         await reachFive.sendEmailVerification(
           accessToken: authToken.accessToken,
+        );
+
+        verify(
+          () => mockEmailApi.sendEmailVerification(
+            authorization: 'Bearer ${authToken.accessToken}',
+            sendEmailVerificationRequest: SendEmailVerificationRequest(),
+          ),
+        ).called(1);
+      });
+
+      test('format custom locale correctly ', () async {
+        const authToken = AuthToken(
+          accessToken: 'accessToken',
+          refreshToken: 'refreshToken',
+          tokenType: 'Bearer',
+        );
+
+        when(
+          () => mockEmailApi.sendEmailVerification(
+            authorization: any(named: 'authorization'),
+            sendEmailVerificationRequest:
+                any(named: 'sendEmailVerificationRequest'),
+            customLocale: any(named: 'customLocale'),
+          ),
+        ).thenAnswer(
+          (_) async {
+            return Response(requestOptions: RequestOptions(path: 'path'));
+          },
+        );
+
+        await reachFive.sendEmailVerification(
+          accessToken: authToken.accessToken,
           customLocale: const Locale('en', 'US'),
         );
 

--- a/flutter_reach_five/test/reach_five_test.dart
+++ b/flutter_reach_five/test/reach_five_test.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_reach_five/flutter_reach_five.dart';
 import 'package:flutter_reach_five/helpers/auth_token.dart';
 import 'package:flutter_reach_five/helpers/profile_converter.dart';
@@ -632,12 +633,14 @@ void main() {
 
         await reachFive.sendEmailVerification(
           accessToken: authToken.accessToken,
+          customLocale: const Locale('en', 'US'),
         );
 
         verify(
           () => mockEmailApi.sendEmailVerification(
             authorization: 'Bearer ${authToken.accessToken}',
             sendEmailVerificationRequest: SendEmailVerificationRequest(),
+            customLocale: 'en-US',
           ),
         ).called(1);
       });

--- a/flutter_reach_five_android/CHANGELOG.md
+++ b/flutter_reach_five_android/CHANGELOG.md
@@ -1,3 +1,28 @@
+## 0.5.1
+
+ - **REFACTOR**(android plugin): improve result type.
+ - **REFACTOR**(platform interface): rename error exception classes.
+ - **REFACTOR**(android converters): extract addressTypeFromInterface.
+ - **REFACTOR**(android): use ReachFiveKeyInterface.
+ - **REFACTOR**(pigeon): add ReachFiveKeyInterface.
+ - **REFACTOR**(android): create and use getReachFiveInstance function.
+ - **FIX**(android): plugin works with AGP 8.3.0.
+ - **FIX**(android): use the correct result class after pigeon update.
+ - **FIX**(android): bump android sdk version that secure intent redirect.
+ - **FIX**(Android parseError): use code instead of message.
+ - **FIX**(android plugin): load social providers after initialization.
+ - **FIX**(android): remove very_good_analysis dev dep.
+ - **FIX**(changelog): use correct versions.
+ - **FIX**(profilesignuprequest): make email optional.
+ - **FEAT**(android): handle unauthorize refresh token exception.
+ - **FEAT**(package): add a proper error for unauthorized refresh token.
+ - **FEAT**: add error handling for updateSamePassword error in android.
+ - **FEAT**: add UpdateSamePassword exception to interface.
+ - **FEAT**(android): add signup method.
+ - **FEAT**(android): initialize reachFive.
+ - **DOCS**(all_packages): link differents documentations.
+ - **DOCS**(every packages): complete readme files.
+
 # 0.5.0
 
 - **BREAKING**: On android: add support for AGP 8.3.0. Breaks compatibility with AGP 7.2.2 and below.

--- a/flutter_reach_five_android/pubspec.yaml
+++ b/flutter_reach_five_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_reach_five_android
 description: Android implementation of the flutter_reach_five plugin
-version: 0.5.0
+version: 0.5.1
 homepage: https://github.com/bamlab/Flutter-ReachFive
 
 environment:
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_reach_five_platform_interface: ^0.4.1
+  flutter_reach_five_platform_interface: ^0.4.2
 
 dev_dependencies:
   flutter_test:

--- a/flutter_reach_five_ios/CHANGELOG.md
+++ b/flutter_reach_five_ios/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 0.4.2
+
+ - **REFACTOR**(platform interface): rename error exception classes.
+ - **REFACTOR**(ios flutterreachfiveplugin): remove redundant return.
+ - **REFACTOR**(ios converters): remove redondant return.
+ - **REFACTOR**(ios converters): extract addressTypeFromInterface.
+ - **REFACTOR**(ios): use ReachFiveKeyInterface.
+ - **REFACTOR**(pigeon): add ReachFiveKeyInterface.
+ - **FIX**(ios converters): use liteOnly variable.
+ - **FIX**(changelog): use correct versions.
+ - **FIX**(profilesignuprequest): make email optional.
+ - **FEAT**(ios): handle unauthorize refresh token exception.
+ - **FEAT**(package): add a proper error for unauthorized refresh token.
+ - **FEAT**: add error handling for updateSamePassword error in iOS.
+ - **FEAT**: add UpdateSamePassword exception to interface.
+ - **FEAT**(ios): add refreshAccessToken method.
+ - **FEAT**(ios): add signup method.
+ - **FEAT**(ios): initialize reachFive.
+ - **DOCS**(all_packages): link differents documentations.
+ - **DOCS**(every packages): complete readme files.
+
 # 0.4.1
 
 - **FEAT**: Add a custom exception thrown when the refresh token is not valid anymore

--- a/flutter_reach_five_ios/pubspec.yaml
+++ b/flutter_reach_five_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_reach_five_ios
 description: iOS implementation of the flutter_reach_five plugin
-version: 0.4.1
+version: 0.4.2
 homepage: https://github.com/bamlab/Flutter-ReachFive
 
 environment:
@@ -18,7 +18,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_reach_five_platform_interface: ^0.4.1
+  flutter_reach_five_platform_interface: ^0.4.2
 
 dev_dependencies:
   flutter_test:

--- a/flutter_reach_five_platform_interface/CHANGELOG.md
+++ b/flutter_reach_five_platform_interface/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 0.4.2
+
+ - **REFACTOR**(platform interface): rename error exception classes.
+ - **REFACTOR**(platform): use ReachFiveKeyInterface.
+ - **REFACTOR**(pigeon): add ReachFiveKeyInterface.
+ - **REFACTOR**(platform interface test): extract ReachFiveConfigInterface.
+ - **FIX**(platform errors): use correct docs links.
+ - **FIX**(platform interface): fix typo in readme.
+ - **FIX**(errors): export new errors from reach five main package.
+ - **FIX**(changelog): use correct versions.
+ - **FIX**(pigeon): format after file generation.
+ - **FIX**(profilesignuprequest): make email optional.
+ - **FEAT**(package): add a proper error for unauthorized refresh token.
+ - **FEAT**: add UpdateSamePassword exception to interface.
+ - **FEAT**(platform_interface): add refreshAccessToken method.
+ - **FEAT**(platform interface): add signup method.
+ - **DOCS**(all_packages): link differents documentations.
+ - **DOCS**(every packages): complete readme files.
+
 # 0.4.1
 
 - **FEAT**: Add a custom exception thrown when the refresh token is not valid anymore

--- a/flutter_reach_five_platform_interface/pubspec.yaml
+++ b/flutter_reach_five_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_reach_five_platform_interface
 description: A common platform interface for the flutter_reach_five plugin.
-version: 0.4.1
+version: 0.4.2
 homepage: https://github.com/bamlab/Flutter-ReachFive
 
 environment:

--- a/reach_five_identity_api.yaml
+++ b/reach_five_identity_api.yaml
@@ -301,6 +301,7 @@ paths:
         - $ref: "#/components/parameters/Authorization"
         - $ref: "#/components/parameters/trueClientIp"
         - $ref: "#/components/parameters/trueClientIpKey"
+        - $ref: "#/components/parameters/Custom-Locale"
       requestBody:
         content:
           application/json:
@@ -381,6 +382,17 @@ components:
         type: string
       required: false
       description: Bearer `{token}` for a valid OAuth token.
+    Custom-Locale:
+      name: Custom-Locale
+      in: header
+      schema:
+        type: string
+      required: false
+      description: |
+        For any endpoint in this specification that generates an
+        email or SMS, you can pass the Custom-Locale attribute as a header
+        parameter.
+      example: fr-FR
     trueClientIp:
       name: True-Client-IP
       in: header

--- a/reach_five_identity_api.yaml
+++ b/reach_five_identity_api.yaml
@@ -42,9 +42,9 @@ tags:
       > **The Step Up Flow**
       > - [startPhoneNumberRegistration](#operation/startPhoneNumberRegistration)
       > - [verifyPhoneNumberRegistration](#operation/verifyPhoneNumberRegistration)
-      
+
       **OR**
-      
+
       > - [startEmailRegistration](#operation/startEmailRegistration)
       > - [verifyEmailRegistration](#operation/verifyEmailRegistration)
 
@@ -205,7 +205,7 @@ info:
 
     # Security Schemes
     <SecurityDefinitions />
-  version: 'latest'
+  version: "latest"
   title: ReachFive Identity API
   termsOfService: https://www.reachfive.com/terms-policies
   contact:
@@ -237,7 +237,7 @@ paths:
         - **access_token**: When an access token is revoked, only the tokens associated with the same specific grant are revoked.
       operationId: revokeToken
       requestBody:
-        description: ''
+        description: ""
         required: true
         content:
           application/json:
@@ -271,10 +271,10 @@ paths:
                 - client_secret
                 - token
       responses:
-        '204':
+        "204":
           description: No Content.
       x-codeSamples:
-        - lang: 'cURL'
+        - lang: "cURL"
           source: |
             curl --request POST \
               --url https://DOMAIN/oauth/revoke \
@@ -355,10 +355,10 @@ components:
       in: header
       schema:
         type: string
-      description: | 
+      description: |
         Bearer `{access_token}` for a valid OAuth token. *(3)*
-        
-        > **Note**: The `access_token` is not required if you are passing the `tkn` as part of the request body or are using an active SSO session by passing the session cookie. 
+
+        > **Note**: The `access_token` is not required if you are passing the `tkn` as part of the request body or are using an active SSO session by passing the session cookie.
       example: 1pz032..32Ld0a
     fields:
       name: fields
@@ -372,7 +372,7 @@ components:
         items:
           type: string
       explode: false
-      example: [name,email,gender,emails.unverified] # https://github.com/Redocly/redoc/issues/1010
+      example: [name, email, gender, emails.unverified] # https://github.com/Redocly/redoc/issues/1010
       allowReserved: true # https://github.com/Redocly/redoc/issues/1010
     Authorization_optional:
       name: Authorization

--- a/reach_five_identity_repo/CHANGELOG.md
+++ b/reach_five_identity_repo/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.1
+
+ - **REFACTOR**(reach_five_repo): rename in reach_five_identity_repo.
+ - **FIX**: correct version for identity repo.
+ - **FEAT**: add custom local for send email endpoint.
+
 # 0.5.0
 
 - **FEAT**: Add a method to handle user email verification

--- a/reach_five_identity_repo/README.md
+++ b/reach_five_identity_repo/README.md
@@ -149,10 +149,11 @@ final api = ReachFiveIdentityRepo().getEmailApi();
 final String authorization = authorization_example; // String | Bearer `{token}` for a valid OAuth token.
 final String trueClientIP = 224.136.62.167; // String | An optional header field; IP to protect requests from the backend.  **Note**: For more details, see [Identity Fraud Protection](https://developer.reachfive.com/docs/ifp.html#enable-true-client-ip-key). 
 final String trueClientIPKey = Isdaf03#@Rasdfj!j3jkl; // String | An optional header field; the secret that must match the True-Client-IP-Key generated in the ReachFive console.  **Note**: For more details, see [Identity Fraud Protection](https://developer.reachfive.com/docs/ifp.html#enable-true-client-ip-key). 
+final String customLocale = fr-FR; // String | For any endpoint in this specification that generates an email or SMS, you can pass the Custom-Locale attribute as a header parameter. 
 final SendEmailVerificationRequest sendEmailVerificationRequest = ; // SendEmailVerificationRequest | 
 
 try {
-    final response = await api.sendEmailVerification(authorization, trueClientIP, trueClientIPKey, sendEmailVerificationRequest);
+    final response = await api.sendEmailVerification(authorization, trueClientIP, trueClientIPKey, customLocale, sendEmailVerificationRequest);
     print(response);
 } catch on DioException (e) {
     print("Exception when calling EmailApi->sendEmailVerification: $e\n");

--- a/reach_five_identity_repo/doc/EmailApi.md
+++ b/reach_five_identity_repo/doc/EmailApi.md
@@ -13,7 +13,7 @@ Method | HTTP request | Description
 
 
 # **sendEmailVerification**
-> SendEmailVerification200Response sendEmailVerification(authorization, trueClientIP, trueClientIPKey, sendEmailVerificationRequest)
+> SendEmailVerification200Response sendEmailVerification(authorization, trueClientIP, trueClientIPKey, customLocale, sendEmailVerificationRequest)
 
 Request verification of the email address
 
@@ -27,10 +27,11 @@ final api = ReachFiveIdentityRepo().getEmailApi();
 final String authorization = authorization_example; // String | Bearer `{token}` for a valid OAuth token.
 final String trueClientIP = 224.136.62.167; // String | An optional header field; IP to protect requests from the backend.  **Note**: For more details, see [Identity Fraud Protection](https://developer.reachfive.com/docs/ifp.html#enable-true-client-ip-key). 
 final String trueClientIPKey = Isdaf03#@Rasdfj!j3jkl; // String | An optional header field; the secret that must match the True-Client-IP-Key generated in the ReachFive console.  **Note**: For more details, see [Identity Fraud Protection](https://developer.reachfive.com/docs/ifp.html#enable-true-client-ip-key). 
+final String customLocale = fr-FR; // String | For any endpoint in this specification that generates an email or SMS, you can pass the Custom-Locale attribute as a header parameter. 
 final SendEmailVerificationRequest sendEmailVerificationRequest = ; // SendEmailVerificationRequest | 
 
 try {
-    final response = api.sendEmailVerification(authorization, trueClientIP, trueClientIPKey, sendEmailVerificationRequest);
+    final response = api.sendEmailVerification(authorization, trueClientIP, trueClientIPKey, customLocale, sendEmailVerificationRequest);
     print(response);
 } catch on DioException (e) {
     print('Exception when calling EmailApi->sendEmailVerification: $e\n');
@@ -44,6 +45,7 @@ Name | Type | Description  | Notes
  **authorization** | **String**| Bearer `{token}` for a valid OAuth token. | 
  **trueClientIP** | **String**| An optional header field; IP to protect requests from the backend.  **Note**: For more details, see [Identity Fraud Protection](https://developer.reachfive.com/docs/ifp.html#enable-true-client-ip-key).  | [optional] 
  **trueClientIPKey** | **String**| An optional header field; the secret that must match the True-Client-IP-Key generated in the ReachFive console.  **Note**: For more details, see [Identity Fraud Protection](https://developer.reachfive.com/docs/ifp.html#enable-true-client-ip-key).  | [optional] 
+ **customLocale** | **String**| For any endpoint in this specification that generates an email or SMS, you can pass the Custom-Locale attribute as a header parameter.  | [optional] 
  **sendEmailVerificationRequest** | [**SendEmailVerificationRequest**](SendEmailVerificationRequest.md)|  | [optional] 
 
 ### Return type

--- a/reach_five_identity_repo/lib/src/api/email_api.dart
+++ b/reach_five_identity_repo/lib/src/api/email_api.dart
@@ -24,10 +24,11 @@ class EmailApi {
   /// * [authorization] - Bearer `{token}` for a valid OAuth token.
   /// * [trueClientIP] - An optional header field; IP to protect requests from the backend.  **Note**: For more details, see [Identity Fraud Protection](https://developer.reachfive.com/docs/ifp.html#enable-true-client-ip-key).
   /// * [trueClientIPKey] - An optional header field; the secret that must match the True-Client-IP-Key generated in the ReachFive console.  **Note**: For more details, see [Identity Fraud Protection](https://developer.reachfive.com/docs/ifp.html#enable-true-client-ip-key).
+  /// * [customLocale] - For any endpoint in this specification that generates an email or SMS, you can pass the Custom-Locale attribute as a header parameter.
   /// * [sendEmailVerificationRequest]
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
-  /// * [extra] - Can be used to add flags to the request
+  /// * [extras] - Can be used to add flags to the request
   /// * [validateStatus] - A [ValidateStatus] callback that can be used to determine request success based on the HTTP status of the response
   /// * [onSendProgress] - A [ProgressCallback] that can be used to get the send progress
   /// * [onReceiveProgress] - A [ProgressCallback] that can be used to get the receive progress
@@ -38,6 +39,7 @@ class EmailApi {
     required String authorization,
     String? trueClientIP,
     String? trueClientIPKey,
+    String? customLocale,
     SendEmailVerificationRequest? sendEmailVerificationRequest,
     CancelToken? cancelToken,
     Map<String, dynamic>? headers,
@@ -53,6 +55,7 @@ class EmailApi {
         r'Authorization': authorization,
         if (trueClientIP != null) r'True-Client-IP': trueClientIP,
         if (trueClientIPKey != null) r'True-Client-IP-Key': trueClientIPKey,
+        if (customLocale != null) r'Custom-Locale': customLocale,
         ...?headers,
       },
       extra: <String, dynamic>{

--- a/reach_five_identity_repo/pubspec.yaml
+++ b/reach_five_identity_repo/pubspec.yaml
@@ -1,5 +1,5 @@
 name: reach_five_identity_repo
-version: 0.5.0
+version: 0.5.1
 description: OpenAPI API client
 homepage: https://github.com/bamlab/Flutter-ReachFive
 


### PR DESCRIPTION
## Description

Add a custom locale to the send verification email method, following ReachFive api documentation: https://developer.reachfive.com/openapi/identity.html#section/User-locale

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
