### PR TITLE
fix: add error.account.temporarilySuspended in case of a RequestError

### DIFF
--- a/flutter_reach_five/CHANGELOG.md
+++ b/flutter_reach_five/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.1
+
+- **FIX**: Also handle account temporarily suspended error (`error.account.temporarilySuspended`) as a RequestError not only TechnicalError in the iOS version
+
 # 2.1.0
 
 - **FEAT**: Add `passwordPolicy` method returning the `PasswordPolicy` configured for the ReachFive client (minimum length, minimum strength, required character classes and whether the password can be updated with only an access token)

--- a/flutter_reach_five/pubspec.yaml
+++ b/flutter_reach_five/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_reach_five
 description: This package allows you to use the methods from the reachFive android and ios native sdks in Flutter
-version: 2.1.0
+version: 2.1.1
 homepage: https://github.com/bamlab/Flutter-ReachFive
 repository: https://github.com/bamlab/Flutter-ReachFive
 
@@ -23,7 +23,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_reach_five_android: ^2.0.5
-  flutter_reach_five_ios: ^2.0.5
+  flutter_reach_five_ios: ^2.0.6
   flutter_reach_five_platform_interface: ^2.0.5
   freezed: ^3.2.3
   freezed_annotation: ^3.1.0

--- a/flutter_reach_five_ios/CHANGELOG.md
+++ b/flutter_reach_five_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.6
+
+- **FIX**: Also handle account temporarily suspended error (`error.account.temporarilySuspended`) as a RequestError not only TechnicalError
+
 # 2.0.5
 
 - **FEAT**: Handle password too weak error (`password_too_weak`)

--- a/flutter_reach_five_ios/ios/flutter_reach_five_ios/Sources/flutter_reach_five_ios/Converters.swift
+++ b/flutter_reach_five_ios/ios/flutter_reach_five_ios/Sources/flutter_reach_five_ios/Converters.swift
@@ -65,6 +65,13 @@ public class Converters {
                         details: nil
                 )
             }
+            if (apiError.errorMessageKey?.hasPrefix("error.account.temporarilySuspended") == true) {
+                return PigeonError(
+                    code: errorCodesInterface.accountTemporarilySuspended,
+                    message: apiError.errorUserMsg,
+                    details: nil
+                )
+            }
             return defaultFlutterError
         case .AuthFailure(reason: _, apiError: let apiError):
             if (apiError?.errorMessageKey == "error.invalidEmailOrPassword") {

--- a/flutter_reach_five_ios/pubspec.yaml
+++ b/flutter_reach_five_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_reach_five_ios
 description: iOS implementation of the flutter_reach_five plugin
-version: 2.0.5
+version: 2.0.6
 homepage: https://github.com/bamlab/Flutter-ReachFive
 
 environment:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->

## Type of Change
iOS : The plugin was only catching error.account.temporarilySuspended as TechnicalError
         -> Now It is also catching it as a RequestError


<!--- Put an `x` in all the boxes that apply: -->

- [] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
